### PR TITLE
Do not remove new lines or change names in paramgen

### DIFF
--- a/paramgen/internal/paramgen.go
+++ b/paramgen/internal/paramgen.go
@@ -551,10 +551,7 @@ func (p *parameterParser) formatFieldComment(f *ast.Field, fieldName, paramName 
 		// fallback to line comment
 		doc = f.Comment
 	}
-	c := strings.ReplaceAll(doc.Text(), fieldName, paramName)
-	if len(c) == 0 {
-		return c
-	}
+	c := doc.Text()
 
 	whitespacePrefix := ""
 	for _, r := range c {
@@ -568,10 +565,8 @@ func (p *parameterParser) formatFieldComment(f *ast.Field, fieldName, paramName 
 	c = strings.TrimPrefix(c, whitespacePrefix)
 	// get rid of whitespace in front of all other lines
 	c = strings.ReplaceAll(c, "\n"+whitespacePrefix, "\n")
-	// get rid of new lines and use a space instead
-	c = strings.ReplaceAll(c, "\n", " ")
 	// trim space (get rid of any eventual new lines at the end)
-	c = strings.Trim(c, " ")
+	c = strings.TrimRight(c, " \n")
 	return c
 }
 

--- a/paramgen/internal/paramgen.go
+++ b/paramgen/internal/paramgen.go
@@ -481,7 +481,7 @@ func (p *parameterParser) parseSingleParameter(f *ast.Field, t config.ParameterT
 
 	return paramName, config.Parameter{
 		Default:     p.getTag(f.Tag, tagParamDefault),
-		Description: p.formatFieldComment(f, fieldName, paramName),
+		Description: p.formatFieldComment(f),
 		Validations: validations,
 		Type:        t,
 	}, nil
@@ -545,7 +545,7 @@ func (p *parameterParser) formatFieldName(name string) string {
 	return newName
 }
 
-func (p *parameterParser) formatFieldComment(f *ast.Field, fieldName, paramName string) string {
+func (p *parameterParser) formatFieldComment(f *ast.Field) string {
 	doc := f.Doc
 	if doc == nil {
 		// fallback to line comment

--- a/paramgen/internal/paramgen_test.go
+++ b/paramgen/internal/paramgen_test.go
@@ -37,14 +37,14 @@ func TestParseSpecificationSuccess(t *testing.T) {
 			want: map[string]config.Parameter{
 				"foo": {
 					Default:     "bar",
-					Description: "foo is a required field in the global config with the name \"foo\" and default value \"bar\".",
+					Description: "MyGlobalString is a required field in the global config with the name\n\"foo\" and default value \"bar\".",
 					Type:        config.ParameterTypeString,
 					Validations: []config.Validation{
 						config.ValidationRequired{},
 					},
 				},
 				"myString": {
-					Description: "myString my string description",
+					Description: "MyString my string description",
 					Type:        config.ParameterTypeString,
 				},
 				"myBool": {Type: config.ParameterTypeBool},
@@ -85,21 +85,21 @@ func TestParseSpecificationSuccess(t *testing.T) {
 			want: map[string]config.Parameter{
 				"global.duration": {
 					Default:     "1s",
-					Description: "duration does not have a name so the type name is used.",
+					Description: "Duration does not have a name so the type name is used.",
 					Type:        config.ParameterTypeDuration,
 				},
 				"nestMeHere.anotherNested": {
 					Type:        config.ParameterTypeInt,
-					Description: "nestMeHere.anotherNested is also nested under nestMeHere. This is a block comment.",
+					Description: "AnotherNested is also nested under nestMeHere.\nThis is a block comment.",
 				},
 				"nestMeHere.formatThisName": {
 					Type:        config.ParameterTypeFloat,
 					Default:     "this is not a float",
-					Description: "formatThisName should become \"formatThisName\". Default is not a float but that's not a problem, paramgen does not validate correctness.",
+					Description: "FORMATThisName should stay \"FORMATThisName\". Default is not a float\nbut that's not a problem, paramgen does not validate correctness.",
 				},
 				"customType": {
 					Type:        config.ParameterTypeDuration,
-					Description: "customType uses a custom type that is convertible to a supported type. Line comments are allowed.",
+					Description: "CustomType uses a custom type that is convertible to a supported type. Line comments are allowed.",
 				},
 			},
 		},
@@ -114,7 +114,7 @@ func TestParseSpecificationSuccess(t *testing.T) {
 				},
 				"my-param": {
 					Type:        config.ParameterTypeInt,
-					Description: "my-param i am a parameter comment",
+					Description: "Param1 i am a parameter comment",
 					Default:     "3",
 					Validations: []config.Validation{
 						config.ValidationRequired{},

--- a/paramgen/internal/testdata/complex/specs.go
+++ b/paramgen/internal/testdata/complex/specs.go
@@ -22,7 +22,7 @@ type SourceConfig struct {
 	Global GlobalConfig `json:"global"`
 	// Nested structs can be used to create namespaces
 	Nested struct {
-		// FORMATThisName should become "formatThisName". Default is not a float
+		// FORMATThisName should stay "FORMATThisName". Default is not a float
 		// but that's not a problem, paramgen does not validate correctness.
 		FORMATThisName float32 `default:"this is not a float"`
 		// unexported fields should be ignored.


### PR DESCRIPTION
### Description

Paramgen is now simpler in the way that it does not remove new lines or change names of parameters in the comments. This will make it more predictable and allow us to write markdown code in documentation (new lines won't be displayed anyway).

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-commons/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
