### PR TITLE
Dynamic config params

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ issues:
         - funlen
         - goerr113
         - dupl
+        - maintidx
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.

--- a/config/config.go
+++ b/config/config.go
@@ -329,13 +329,14 @@ func mapStringHookFunc() mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
-		data interface{}) (interface{}, error) {
+		data interface{},
+	) (interface{}, error) {
 		if f.Kind() != reflect.Map || f.Elem().Kind() != reflect.Interface ||
 			t.Kind() != reflect.Map || t.Elem().Kind() != reflect.String {
 			return data, nil
 		}
 
-		// no need to assert, we know it's a map[string]any
+		//nolint:forcetypeassert // We checked in the condition above and know it's a map[string]any
 		dataMap := data.(map[string]any)
 
 		// remove all keys with maps
@@ -353,13 +354,14 @@ func mapStructHookFunc() mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
-		data interface{}) (interface{}, error) {
+		data interface{},
+	) (interface{}, error) {
 		if f.Kind() != reflect.Map || f.Elem().Kind() != reflect.Interface ||
 			t.Kind() != reflect.Map || t.Elem().Kind() != reflect.Struct {
 			return data, nil
 		}
 
-		// no need to assert, we know it's a map[string]any
+		//nolint:forcetypeassert // We checked in the condition above and know it's a map[string]any
 		dataMap := data.(map[string]any)
 
 		// remove all keys with a dot that contains a value with a string

--- a/config/config.go
+++ b/config/config.go
@@ -219,11 +219,14 @@ func (c Config) getKeysForParameter(key string) []string {
 				break
 			}
 
-			// Between tokens there is a wildcard, we need to strip the key until
-			// the next ".".
-			_, k, ok = strings.Cut(k, ".")
-			if ok {
-				k = "." + k // Add the "." back to the key.
+			// Between tokens there is a wildcard, we need to consume the key
+			// until the next ".". If there is no next ".", the whole key is
+			// consumed.
+			// e.g. "foo.format" -> ".format" or "foo" -> ""
+			if index := strings.IndexRune(k, '.'); index != -1 {
+				k = k[index:]
+			} else {
+				k = ""
 			}
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1013,5 +1013,4 @@ func TestConfig_getValuesForParameter(t *testing.T) {
 			is.Equal(cmp.Diff(tc.want, got), "")
 		})
 	}
-
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -903,7 +903,8 @@ func TestBreakUpConfig_Conflict_Value(t *testing.T) {
 
 func TestConfig_getValuesForParameter(t *testing.T) {
 	cfg := Config{
-		"ignore": "me",
+		"ignore":          "me",
+		"ignore.foo.this": "me",
 
 		// foo
 		"test.foo.val": "0",
@@ -1000,6 +1001,34 @@ func TestConfig_getValuesForParameter(t *testing.T) {
 			"test.foo.format.qux.options",
 			"test.bar.format.baz.options",
 			"test.bar.format.qux.options",
+		},
+	}, {
+		key: "*",
+		want: []string{
+			"ignore",
+			"ignore.foo.this",
+			"test.foo.val",
+			"test.foo.format.baz.type",
+			"test.foo.format.baz.options",
+			"test.foo.format.qux.type",
+			"test.foo.format.qux.options",
+			"test.bar.val",
+			"test.bar.format.baz.type",
+			"test.bar.format.baz.options",
+			"test.bar.format.qux.type",
+			"test.bar.format.qux.options",
+			"test.include.me",
+			"test.ignore",
+		},
+	}, {
+		key: "*.foo.*",
+		want: []string{
+			"ignore.foo.this",
+			"test.foo.val",
+			"test.foo.format.baz.type",
+			"test.foo.format.baz.options",
+			"test.foo.format.qux.type",
+			"test.foo.format.qux.options",
 		},
 	}}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -247,7 +247,7 @@ func TestConfig_Validate_Validations(t *testing.T) {
 		wantErr: true,
 		err:     ErrGreaterThanValidationFail,
 	}, {
-		name:   "greater than validation failed",
+		name:   "greater than validation pass",
 		config: Config{"param1": "20"},
 		params: Parameters{
 			"param1": {Validations: []Validation{
@@ -385,7 +385,7 @@ func TestConfig_Validate_Validations(t *testing.T) {
 		wantErr: true,
 		err:     ErrGreaterThanValidationFail,
 	}, {
-		name:   "dynamic: greater than validation failed",
+		name:   "dynamic: greater than validation pass",
 		config: Config{"foo.0.param1": "20"},
 		params: Parameters{
 			"foo.*.param1": {Validations: []Validation{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -429,6 +429,10 @@ func TestParseConfig_Embedded_Struct(t *testing.T) {
 
 func TestParseConfig_All_Types(t *testing.T) {
 	is := is.New(t)
+	type structMapVal struct {
+		MyString string
+		MyInt    int
+	}
 	type testCfg struct {
 		MyString      string
 		MyBool1       bool
@@ -459,6 +463,12 @@ func TestParseConfig_All_Types(t *testing.T) {
 		MySlice      []string
 		MyIntSlice   []int
 		MyFloatSlice []float32
+
+		Nested struct {
+			MyString string
+		}
+		StringMap map[string]string
+		StructMap map[string]structMapVal
 	}
 
 	input := Config{
@@ -488,6 +498,17 @@ func TestParseConfig_All_Types(t *testing.T) {
 		"myslice":      "1,2,3,4",
 		"myIntSlice":   "1,2,3,4",
 		"myFloatSlice": "1.1,2.2",
+
+		"nested.mystring": "string",
+
+		"stringmap.foo":     "1",
+		"stringmap.bar":     "2",
+		"stringmap.baz.qux": "3",
+
+		"structmap.foo.mystring": "foo-name",
+		"structmap.foo.myint":    "1",
+		"structmap.bar.mystring": "bar-name",
+		"structmap.bar.myint":    "-1",
 	}
 	want := testCfg{
 		MyString:          "string",
@@ -514,6 +535,16 @@ func TestParseConfig_All_Types(t *testing.T) {
 		MySlice:           []string{"1", "2", "3", "4"},
 		MyIntSlice:        []int{1, 2, 3, 4},
 		MyFloatSlice:      []float32{1.1, 2.2},
+		Nested:            struct{ MyString string }{MyString: "string"},
+		StringMap: map[string]string{
+			"foo":     "1",
+			"bar":     "2",
+			"baz.qux": "3",
+		},
+		StructMap: map[string]structMapVal{
+			"foo": {MyString: "foo-name", MyInt: 1},
+			"bar": {MyString: "bar-name", MyInt: -1},
+		},
 	}
 
 	var result testCfg


### PR DESCRIPTION
### Description

This PR adds support for dynamic config parameters. A specification can now define parameters using wildcards to define dynamic parameters.

For instance, a specification parameter with the name `collections.*.format` will match multiple keys (e.g. `collections.foo.format`, `collections.bar.format`). The only limitation is that the word behind the wildcard can't contain a dot `.`, as dots are used as a hierarchical separator.

#### Validations

Validations work the same as before.

#### Defaults

Default values will be applied to all parameters that contain the same prefix up to the last wildcard, as soon as at least one of them is found in the supplied config.

For example, say a connector specification defines the following parameters:

- `collections.*.name`, default value: `default-name`
- `collections.*.type`, default value: `default-type`

If the user supplies the following configuration:

```yaml
collections.foo.name: "my-foo-name"
collections.bar.type: "my-bar-type"
```

The default values will be populated like this:

```yaml
collections.foo.name: "my-foo-name"
collections.foo.type: "default-type" # populated because collection.foo.name was found
collections.bar.name: "default-name" # populated because collection.bar.type was found
collections.bar.type: "my-bar-type"
```

#### Parsing

Parameters with wildcards can be parsed into a `map[string]string` or `map[string]myStruct` field using the method `Config.DecodeInto`.

Parsing into a `map[string]string` is useful when the last key is a wildcard. For example an HTTP connector might want to specify a parameter `headers.*` that lets the user specify custom headers in separate config parameters:

```yaml
headers.content_type: "application/json"
headers.authorization: "basic ZGVtbzpwQDU1dzByZA=="
```

Parsing into a `map[string]myStruct` allows you to specify the nested fields after the wildcard. This is useful when you want to configure multiple groups of values and know what fields to expect in each group (see the `collections` example above).

---

Part of https://github.com/ConduitIO/conduit/issues/1487

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-commons/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
