### PR TITLE
Config - Don't populate empty defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,7 +51,7 @@ func (c Config) Sanitize() Config {
 func (c Config) ApplyDefaults(params Parameters) Config {
 	for key, param := range params {
 		for _, key := range c.getKeysForParameter(key) {
-			if strings.TrimSpace(c[key]) == "" {
+			if strings.TrimSpace(c[key]) == "" && param.Default != "" {
 				c[key] = param.Default
 			}
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -621,7 +621,7 @@ func TestConfig_ApplyDefaults(t *testing.T) {
 		want: Config{
 			"limit":        "-1",
 			"foo.0.param1": "custom",
-			"foo.0.param2": "",
+			// empty defaults are not populated
 		},
 	}, {
 		name: "multiple dynamic params",
@@ -634,11 +634,9 @@ func TestConfig_ApplyDefaults(t *testing.T) {
 		want: Config{
 			"limit":                "-1",
 			"foo.0.param1":         "parameter",
-			"foo.0.param2":         "",
 			"foo.1.param1":         "foo",
 			"foo.1.param2":         "custom",
 			"foo.2.param1":         "foo",
-			"foo.2.param2":         "",
 			"foo.2.does-not-exist": "unrecognized key still triggers creation of defaults",
 		},
 	}}


### PR DESCRIPTION
### Description

I noticed a strange behavior in the generator connector because the SDK populated fields that had no defaults. Now defaults are only populated if the field actually has a default value.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-commons/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
