### PR TITLE
fix: sanitize with nil configurations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,12 @@ import (
 type Config map[string]string
 
 // Sanitize removes leading and trailing spaces from all keys and values in the
-// configuration.
+// configuration, and makes sure it's not nil.
 func (c Config) Sanitize() Config {
+	if c == nil {
+		return map[string]string{}
+	}
+
 	for key, val := range c {
 		delete(c, key)
 		key = strings.TrimSpace(key)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,12 +26,30 @@ import (
 )
 
 func TestConfig_Sanitize(t *testing.T) {
-	is := is.New(t)
-	have := Config{"   key   ": "   value   "}
-	want := Config{"key": "value"}
+	tests := []struct {
+		name string
+		have Config
+		want Config
+	}{
+		{
+			name: "nil config",
+			have: nil,
+			want: map[string]string{},
+		},
+		{
+			name: "with spaces",
+			have: Config{"   key   ": "   value   "},
+			want: Config{"key": "value"},
+		},
+	}
 
-	have.Sanitize()
-	is.Equal(have, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is := is.New(t)
+			got := tt.have.Sanitize()
+			is.Equal(got, tt.want)
+		})
+	}
 }
 
 func TestConfig_Validate_ParameterType(t *testing.T) {


### PR DESCRIPTION
### Description

Fixes https://github.com/ConduitIO/conduit/issues/1480

Updates the `Sanitize` method to check when specified configuration is `nil`.

**Before**

```bash
curl 'http://localhost:8080/v1/connectors' \  
  -H 'content-type: application/json; charset=utf-8' \
  --data-raw '{
    "config": {
      "name": "test"
    },
    "type": "TYPE_DESTINATION",
    "plugin": "builtin:log@v0.3.0",
    "pipeline_id": "fd5ab648-7242-4ff6-b3f7-efe7aec10bea"
  }'

  {"code":9, "message":"failed to create connector: invalid connector config: validation error: assignment to entry in nil map", "details":[]}%                                                                                                                                                                             
  ```

**After**

```bash
curl 'http://localhost:8080/v1/connectors' \  
  -H 'content-type: application/json; charset=utf-8' \
  --data-raw '{
    "config": {
      "name": "test"
    },
    "type": "TYPE_DESTINATION",
    "plugin": "builtin:log@v0.3.0",
    "pipeline_id": "fd5ab648-7242-4ff6-b3f7-efe7aec10bea"
  }'

  {"id":"e041093a-4e43-47a0-b12e-328c02249d39","config":{"name":"test","settings":{}},"type":"TYPE_DESTINATION","plugin":"builtin:log@v0.3.0","pipelineId":"fd5ab648-7242-4ff6-b3f7-efe7aec10bea","processorIds":[],"createdAt":"2024-05-09T11:41:14.241103Z","updatedAt":"2024-05-09T11:41:14.241103Z"}%
  ```

****

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-commons/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
