### PR TITLE
Add pointer utility function

### DIFF
--- a/clang/clang.go
+++ b/clang/clang.go
@@ -1,0 +1,19 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clang
+
+func Ptr[T any](t T) *T {
+	return &t
+}

--- a/lang/clang.go
+++ b/lang/clang.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package clang
+package lang
 
 func Ptr[T any](t T) *T {
 	return &t


### PR DESCRIPTION
### Description

Adds a utility function that makes it possible to get a pointer to a literal value, e.g.:
```go
p := Ptr("test")
```

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-commons/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
